### PR TITLE
Minor command based refactor

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -133,7 +133,7 @@ public class RobotContainer {
         //joystick.x().onTrue(new Outtake(m_launcher));
         joystick.a().onTrue(new OuttakeSecond(m_launcher));
         joystick.x().onTrue(new OuttakeFirst(m_launcher));
-        joystick.povLeft().whileTrue(new Throwup(m_launcher));
+        joystick.povLeft().whileTrue(new Throwup(m_launcher).withTimeout(2));
         joystick.rightBumper().onTrue(new StopIntake(m_launcher));
         joystick.povDown().whileTrue(new ClimbDown(m_climber));
         joystick.povUp().whileTrue(new ClimbUp(m_climber));

--- a/src/main/java/frc/robot/commands/ClimbDown.java
+++ b/src/main/java/frc/robot/commands/ClimbDown.java
@@ -23,10 +23,6 @@ public class ClimbDown extends Command{
 
     @Override
     public void end(boolean interrupted) {
-        stop();
-    }
-
-    public void stop() {
         m_Climber.stop();
     }
 }

--- a/src/main/java/frc/robot/commands/ClimbDown.java
+++ b/src/main/java/frc/robot/commands/ClimbDown.java
@@ -23,10 +23,10 @@ public class ClimbDown extends Command{
 
     @Override
     public void end(boolean interrupted) {
-        m_Climber.stop();
+        stop();
     }
 
-    public void stopOuttake() {
+    public void stop() {
         m_Climber.stop();
     }
 }

--- a/src/main/java/frc/robot/commands/ClimbUp.java
+++ b/src/main/java/frc/robot/commands/ClimbUp.java
@@ -23,6 +23,10 @@ public class ClimbUp extends Command{
 
     @Override
     public void end(boolean interrupted) {
+        stop();
+    }
+
+    public void stop() {
         m_Climber.stop();
     }
 }

--- a/src/main/java/frc/robot/commands/ClimbUp.java
+++ b/src/main/java/frc/robot/commands/ClimbUp.java
@@ -23,10 +23,6 @@ public class ClimbUp extends Command{
 
     @Override
     public void end(boolean interrupted) {
-        stop();
-    }
-
-    public void stop() {
         m_Climber.stop();
     }
 }

--- a/src/main/java/frc/robot/commands/Intake.java
+++ b/src/main/java/frc/robot/commands/Intake.java
@@ -26,10 +26,6 @@ public class Intake extends Command{
 
     @Override
     public void end(boolean interrupted) {
-        stop();
-    }
-
-    public void stop() {
         m_launcher.setIntakeWheel(0);
         m_launcher.setOuttakeWheel(0);
     }

--- a/src/main/java/frc/robot/commands/Intake.java
+++ b/src/main/java/frc/robot/commands/Intake.java
@@ -26,11 +26,10 @@ public class Intake extends Command{
 
     @Override
     public void end(boolean interrupted) {
-        m_launcher.setIntakeWheel(0);
-        m_launcher.setOuttakeWheel(0);
+        stop();
     }
 
-    public void stopIntake() {
+    public void stop() {
         m_launcher.setIntakeWheel(0);
         m_launcher.setOuttakeWheel(0);
     }

--- a/src/main/java/frc/robot/commands/OuttakeFirst.java
+++ b/src/main/java/frc/robot/commands/OuttakeFirst.java
@@ -27,11 +27,10 @@ public class OuttakeFirst extends Command{
 
     @Override
     public void end(boolean interrupted) {
-        m_launcher.setIntakeWheel(0);
-        m_launcher.setOuttakeWheel(0);
+        stop();
     }
 
-    public void stopOuttake() {
+    public void stop() {
         m_launcher.setIntakeWheel(0);
         m_launcher.setOuttakeWheel(0);
     }

--- a/src/main/java/frc/robot/commands/OuttakeFirst.java
+++ b/src/main/java/frc/robot/commands/OuttakeFirst.java
@@ -27,10 +27,6 @@ public class OuttakeFirst extends Command{
 
     @Override
     public void end(boolean interrupted) {
-        stop();
-    }
-
-    public void stop() {
         m_launcher.setIntakeWheel(0);
         m_launcher.setOuttakeWheel(0);
     }

--- a/src/main/java/frc/robot/commands/OuttakeSecond.java
+++ b/src/main/java/frc/robot/commands/OuttakeSecond.java
@@ -26,10 +26,6 @@ public class OuttakeSecond extends Command{
 
     @Override
     public void end(boolean interrupted) {
-        stop();
-    }
-
-    public void stop() {
         m_launcher.setIntakeWheel(0);
         m_launcher.setOuttakeWheel(0);
     }

--- a/src/main/java/frc/robot/commands/OuttakeSecond.java
+++ b/src/main/java/frc/robot/commands/OuttakeSecond.java
@@ -26,11 +26,10 @@ public class OuttakeSecond extends Command{
 
     @Override
     public void end(boolean interrupted) {
-        m_launcher.setIntakeWheel(0);
-        m_launcher.setOuttakeWheel(0);
+        stop();
     }
 
-    public void stopOuttake() {
+    public void stop() {
         m_launcher.setIntakeWheel(0);
         m_launcher.setOuttakeWheel(0);
     }

--- a/src/main/java/frc/robot/commands/StopIntake.java
+++ b/src/main/java/frc/robot/commands/StopIntake.java
@@ -22,10 +22,6 @@ public class StopIntake extends Command{
 
     @Override
     public void end(boolean interrupted) {
-        stop();
-    }
-
-    public void stop() {
         m_launcher.setIntakeWheel(0);
         m_launcher.setOuttakeWheel(0);
     }

--- a/src/main/java/frc/robot/commands/StopIntake.java
+++ b/src/main/java/frc/robot/commands/StopIntake.java
@@ -22,11 +22,10 @@ public class StopIntake extends Command{
 
     @Override
     public void end(boolean interrupted) {
-        m_launcher.setIntakeWheel(0);
-        m_launcher.setOuttakeWheel(0);
+        stop();
     }
 
-    public void stopIntake() {
+    public void stop() {
         m_launcher.setIntakeWheel(0);
         m_launcher.setOuttakeWheel(0);
     }

--- a/src/main/java/frc/robot/commands/StopIntake.java
+++ b/src/main/java/frc/robot/commands/StopIntake.java
@@ -1,28 +1,13 @@
 package frc.robot.commands;
 
-import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.robot.subsystems.CoralLauncher;
 
-public class StopIntake extends Command{
-    private CoralLauncher m_launcher;
+public class StopIntake extends InstantCommand {
     public StopIntake(CoralLauncher launcher) {
-        m_launcher = launcher;
-        addRequirements(m_launcher);
-    }
-
-    @Override
-    public void initialize() {
-        m_launcher.setIntakeWheel(0);
-        m_launcher.setOuttakeWheel(0);
-    }
-    @Override
-    public boolean isFinished() {
-        return true;
-    }
-
-    @Override
-    public void end(boolean interrupted) {
-        m_launcher.setIntakeWheel(0);
-        m_launcher.setOuttakeWheel(0);
+        super(() -> {
+            launcher.setIntakeWheel(0);
+            launcher.setOuttakeWheel(0);
+        }, launcher);
     }
 }

--- a/src/main/java/frc/robot/commands/Throwup.java
+++ b/src/main/java/frc/robot/commands/Throwup.java
@@ -26,11 +26,10 @@ public class Throwup extends Command{
 
     @Override
     public void end(boolean interrupted) {
-        m_launcher.setIntakeWheel(0);
-        m_launcher.setOuttakeWheel(0);
+        stop();
     }
 
-    public void stopOuttake() {
+    public void stop() {
         m_launcher.setIntakeWheel(0);
         m_launcher.setOuttakeWheel(0);
     }

--- a/src/main/java/frc/robot/commands/Throwup.java
+++ b/src/main/java/frc/robot/commands/Throwup.java
@@ -19,10 +19,6 @@ public class Throwup extends Command{
 
     @Override
     public void end(boolean interrupted) {
-        stop();
-    }
-
-    public void stop() {
         m_launcher.setIntakeWheel(0);
         m_launcher.setOuttakeWheel(0);
     }

--- a/src/main/java/frc/robot/commands/Throwup.java
+++ b/src/main/java/frc/robot/commands/Throwup.java
@@ -6,7 +6,6 @@ import frc.robot.subsystems.CoralLauncher;
 
 public class Throwup extends Command{
     private CoralLauncher m_launcher;
-    private Timer time = new Timer();
     public Throwup(CoralLauncher launcher) {
         m_launcher = launcher;
         addRequirements(m_launcher);
@@ -16,12 +15,6 @@ public class Throwup extends Command{
     public void initialize() {
         m_launcher.setIntakeWheel(-1);
         m_launcher.setOuttakeWheel(-1);
-        time.reset();
-        time.start();
-    }
-    @Override
-    public boolean isFinished() {
-        return time.get() > 2;
     }
 
     @Override


### PR DESCRIPTION
- Use `extends InstantCommand` for stopping intake as it only needs to execute once and stop immediately; removes redundancy in `initialize` and `end`.
- Prefer using `withTimeout(timeInSeconds)` when possible (e.g. Throwup)
- Prefer using `end` and avoid adding additional public methods that are unused outside of a given class.

Open Questions:
- Do we want to be able to handle a bad intake during auto? Maybe using custom logic leveraging coral sensor & timer?